### PR TITLE
fix(build): shim `process` so PGlite init works in the production bundle

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,6 +6,14 @@ import path from "path";
 
 // https://vite.dev/config/
 export default defineConfig({
+  // PGlite's Emscripten runtime references a bare `process` (e.g. `process.exitCode`)
+  // without a Node-environment guard. Vite only statically replaces `process.env.*`,
+  // so in the production browser bundle `process` is undefined and DB init throws
+  // "process is not defined". Define a minimal global shim — kept free of
+  // `versions.node` so Emscripten still selects the browser code path.
+  define: {
+    process: "(globalThis.process ??= { env: {}, argv: [] })",
+  },
   plugins: [
     react(),
     tailwindcss(),


### PR DESCRIPTION
PGlite's Emscripten runtime writes `process.exitCode` without a Node guard. Vite only statically replaces `process.env.*`, so bare `process` is undefined in the production browser bundle and DB init threw "process is not defined" (dev served PGlite unbundled, so it didn't surface there). Define a minimal global `process` shim via Vite `define`; it omits `versions.node` so Emscripten still selects the browser code path, and React stays in production mode.