### PR TITLE
feat(presentation): fullscreen + landscape with Escape-to-exit

### DIFF
--- a/frontend/src/components/SearchBar.tsx
+++ b/frontend/src/components/SearchBar.tsx
@@ -67,10 +67,7 @@ export default function SearchBar({ onSelectResult, className = "" }: SearchBarP
       const clickedInFilters = filtersContainerRef.current?.contains(target);
       const clickedInContainer = searchContainerRef.current?.contains(target);
       const targetElement = target as HTMLElement;
-      const clickedOnSearchInput =
-        targetElement.tagName === "INPUT" &&
-        (targetElement as HTMLInputElement).type === "text" &&
-        clickedInContainer;
+      const clickedOnSearchInput = targetElement.tagName === "INPUT" && (targetElement as HTMLInputElement).type === "text" && clickedInContainer;
 
       if (filtersContainerRef.current && (!clickedInFilters || clickedOnSearchInput)) {
         filtersContainerRef.current.removeAttribute("open");
@@ -104,21 +101,21 @@ export default function SearchBar({ onSelectResult, className = "" }: SearchBarP
 
   return (
     <div ref={searchContainerRef} className={`relative w-full ${className}`}>
-      <div className="flex w-full gap-2">
+      <div className="flex w-full join">
         <SearchInput
           key={searchInputKey}
-          className="flex-1"
+          className="flex-1 join-item"
           placeholder="ابحث عن ترنيمة، آية من الكتاب مقدس، أو نص..."
           onSearch={handleSearch}
           onInputChange={handleInputChange}
         />
 
         {/* Filter Toggle Button */}
-        <details className="dropdown dropdown-end" ref={filtersContainerRef}>
-          <summary className="btn btn-sm lg:btn-lg btn-neutral">
-            <FiFilter className="h-4 w-4" />
+        <details className="dropdown dropdown-end join-item" ref={filtersContainerRef}>
+          <summary className="btn btn-sm lg:btn-lg btn-accent">
+            <FiFilter className="h-3 w-3 lg:h-4 lg:w-5" />
           </summary>
-          <div className="flex flex-col gap-2 dropdown-content mt-2 p-4 border border-base-300 rounded-box shadow-lg z-50 w-50 lg:w-64 max-w-68 bg-base-200 max-h-[40vh] overflow-y-auto">
+          <div className="flex flex-col gap-2 dropdown-content mt-2 p-4 border border-base-200 rounded-box shadow-lg z-50 w-50 lg:w-64 max-w-68 bg-base-100 max-h-[40vh] overflow-y-auto">
             <div className="text-sm font-bold">تصفية النتائج</div>
             {FILTER_GROUPS.map(({ group, title }) => (
               <div key={group} className="flex flex-col gap-2">
@@ -157,14 +154,8 @@ export default function SearchBar({ onSelectResult, className = "" }: SearchBarP
           ) : (
             <ul className="menu p-2 w-full">
               {searchResults.map((result, index) => {
-                const TitleIcon =
-                  result.titleIconName === "music" ? FiMusic :
-                  result.titleIconName === "book-open" ? FiBookOpen :
-                  FiAlignRight;
-                const SubtitleIcon =
-                  result.subTitleIconName === "user" ? FiUser :
-                  result.subTitleIconName === "book-open" ? FiBookOpen :
-                  FiBook;
+                const TitleIcon = result.titleIconName === "music" ? FiMusic : result.titleIconName === "book-open" ? FiBookOpen : FiAlignRight;
+                const SubtitleIcon = result.subTitleIconName === "user" ? FiUser : result.subTitleIconName === "book-open" ? FiBookOpen : FiBook;
 
                 return (
                   <li key={`${result._resource_uuid}-${index}`}>

--- a/frontend/src/components/base/Header.tsx
+++ b/frontend/src/components/base/Header.tsx
@@ -120,7 +120,7 @@ export default function Header() {
           }}
         >
           <summary className={isBiblePage ? "text-base-content font-medium" : "text-base-content/40 hover:text-base-content"}>الكتاب المقدس</summary>
-          <ul className="m-4 w-64 no-scrollbar lg:w-80 max-h-96 overflow-y-auto bg-base-200 rounded-box shadow-lg z-50">
+          <ul className="m-4 w-64 no-scrollbar lg:w-80 max-h-96 overflow-y-auto bg-base-200 rounded-box shadow-lg z-99">
             {loading ? (
               <li className="text-center py-4">
                 <span className="loading loading-spinner loading-sm"></span>

--- a/frontend/src/components/base/SearchInput.tsx
+++ b/frontend/src/components/base/SearchInput.tsx
@@ -35,27 +35,12 @@ export default function SearchInput({ onSearch, onInputChange, placeholder = "ب
     onInputChangeRef.current?.(e.target.value);
   };
 
-  const handleClear = () => {
-    setValue("");
-    onInputChangeRef.current?.("");
-  };
-
   return (
     <div className={`relative flex items-center ${className}`}>
-      <FiSearch className="absolute right-3 lg:right-4 w-4 h-4 lg:w-5 lg:h-5 text-base-content/40 pointer-events-none z-10" />
-      <input
-        type="text"
-        dir="rtl"
-        className="input input-bordered input-sm lg:input-lg w-full pr-9 lg:pr-12 pl-8 lg:pl-10"
-        placeholder={placeholder}
-        value={value}
-        onChange={handleChange}
-      />
-      {value ? (
-        <button className="absolute left-2 lg:left-3 btn btn-ghost btn-xs btn-circle" onClick={handleClear} aria-label="مسح البحث">
-          <FiX className="w-3 h-3 lg:w-4 lg:h-4" />
-        </button>
-      ) : null}
+      <label className="input input-bordered input-sm lg:input-lg w-full p-2 lg:p-3">
+        <FiSearch className="text-base-content/40" />
+        <input type="search" dir="rtl" placeholder={placeholder} value={value} onChange={handleChange} />
+      </label>
     </div>
   );
 }

--- a/frontend/src/contexts/PresentationContext.tsx
+++ b/frontend/src/contexts/PresentationContext.tsx
@@ -25,10 +25,7 @@ interface PresentationProviderProps {
   startSlide?: string;
 }
 
-async function loadPresentation(
-  db: any,
-  uuid: string
-): Promise<{ contentId: string; contentType: string; segments: PresentationSegment[] }> {
+async function loadPresentation(db: any, uuid: string): Promise<{ contentId: string; contentType: string; segments: PresentationSegment[] }> {
   const res = await db.query(`SELECT get_content_slides($1)::json as r`, [uuid]);
   if (res.rows.length === 0) throw new Error("not found");
   const raw = (res.rows[0] as { r: ContentSlidesView }).r;
@@ -172,4 +169,3 @@ export function usePresentation() {
   }
   return context;
 }
-

--- a/frontend/src/hooks/useFullscreenLandscape.ts
+++ b/frontend/src/hooks/useFullscreenLandscape.ts
@@ -1,0 +1,63 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * On mount: request fullscreen on the document and lock orientation to landscape.
+ * On unmount: unlock orientation and exit fullscreen.
+ *
+ * `onExitFullscreen` fires when the user leaves fullscreen *while mounted* — e.g.
+ * by pressing Escape, which the browser intercepts to exit fullscreen instead of
+ * dispatching a keydown to the page. This lets the caller restore "Escape goes
+ * back" behaviour. It is NOT fired by the unmount cleanup.
+ *
+ * All fullscreen/orientation calls are best-effort (fullscreen may need a user
+ * gesture and orientation lock is unsupported on most desktops), so failures are
+ * ignored.
+ */
+export function useFullscreenLandscape(onExitFullscreen?: () => void): void {
+  const onExitRef = useRef(onExitFullscreen);
+  onExitRef.current = onExitFullscreen;
+
+  useEffect(() => {
+    let entered = false;
+
+    const handleFullscreenChange = () => {
+      if (document.fullscreenElement) {
+        entered = true;
+      } else if (entered) {
+        entered = false;
+        onExitRef.current?.();
+      }
+    };
+    document.addEventListener("fullscreenchange", handleFullscreenChange);
+
+    (async () => {
+      try {
+        if (!document.fullscreenElement) {
+          await document.documentElement.requestFullscreen?.();
+        }
+      } catch {
+        /* fullscreen blocked/unavailable */
+      }
+      try {
+        const orientation = window.screen?.orientation as (ScreenOrientation & { lock?: (orientation: string) => Promise<void> }) | undefined;
+        await orientation?.lock?.("landscape");
+      } catch {
+        /* orientation lock unsupported */
+      }
+    })();
+
+    return () => {
+      // Remove the listener before exiting so the cleanup's own exit doesn't
+      // re-trigger onExitFullscreen.
+      document.removeEventListener("fullscreenchange", handleFullscreenChange);
+      try {
+        window.screen?.orientation?.unlock?.();
+      } catch {
+        /* noop */
+      }
+      if (document.fullscreenElement) {
+        document.exitFullscreen().catch(() => {});
+      }
+    };
+  }, []);
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -49,6 +49,13 @@ body {
   direction: rtl;
 }
 
+[type="search"]::-webkit-search-cancel-button {
+  @apply w-3 h-3 lg:w-4 lg:h-4;
+  -webkit-appearance: none;
+  appearance: none;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 24 24%22><path d=%22M6 6L18 18M18 6L6 18%22 stroke=%22black%22 stroke-width=%222%22/></svg>");
+}
+
 :root:root {
   /* Surfaces & text — light/dark toasts follow the active daisyUI theme */
   --toastify-color-light: var(--color-base-100);

--- a/frontend/src/layouts/RootLayout.tsx
+++ b/frontend/src/layouts/RootLayout.tsx
@@ -10,7 +10,7 @@ export default function RootLayout() {
       <Header />
 
       {/* Main Content */}
-      <main className="flex-1 w-10/12 mx-auto">
+      <main className="flex-1 w-11/12 lg:w-10/12 mx-auto">
         <Outlet />
       </main>
 

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -23,21 +23,21 @@ export default function HomePage() {
   return (
     <div className="flex flex-col items-center min-h-screen py-8">
       <FABCreate />
-      <div className="w-full max-w-6xl px-4 flex flex-col gap-10">
+      <div className="w-full px-4 flex flex-col gap-10">
         {/* Enhanced Hero Section with Background Image */}
         <div className="relative rounded-3xl shadow-2xl flex flex-col gap-6 lg:gap-12 p-8 md:p-26 lg:p-32">
           {/* Background Image with Overlay */}
-          <div className="absolute inset-0 bg-cover bg-center rounded-box" style={{ backgroundImage: "url('/hero.jpg')" }}></div>
+          <div className="absolute inset-0 bg-cover bg-start rounded-box" style={{ backgroundImage: "url('/hero.jpg')" }}></div>
 
           {/* Gradient Overlay for better text readability */}
           <div className="absolute inset-0 bg-linear-to-br from-transparent via-base-100/80 to-transparent rounded-box"></div>
 
           {/* Hero Text */}
           <div className="text-center flex flex-col gap-2 lg:gap-6 fade-in-bottom">
-            <h1 className="text-2xl lg:text-6xl stroke-3 stroke-base-content font-extrabold drop-shadow-2xl text-shadow-lg text-base-content">
+            <h1 className="text-2xl md:text-4xl lg:text-6xl stroke-3 stroke-base-content font-extrabold drop-shadow-2xl text-shadow-lg text-base-content">
               أهلاً بك في هيمنوس
               <sup className="text-2xl align-super">
-                <a href="#footnote-1" className="underline text-blue-800 text-sm font-nor">
+                <a href="#footnote-1" className="underline text-blue-800/80 text-[8px]">
                   1
                 </a>
               </sup>

--- a/frontend/src/routes/presentation/[uuid].tsx
+++ b/frontend/src/routes/presentation/[uuid].tsx
@@ -7,6 +7,7 @@ import SlideContent from "../../components/presentation/SlideContent";
 import { Toolbar, PlusButton } from "../../components/presentation/Toolbar";
 import BackgroundModal from "../../components/presentation/BackgroundModal";
 import BookTocDrawer, { BOOK_TOC_DRAWER_ID } from "../../components/presentation/BookTocDrawer";
+import { useFullscreenLandscape } from "@hooks/useFullscreenLandscape";
 import Logo from "../../components/presentation/Logo";
 import Loader from "../../components/base/Loader";
 import useHymnosStore from "../../store";
@@ -37,6 +38,11 @@ function PresentationContent() {
       });
     }
   }, [state.contentType, state.contentId, state.isLoading, db]);
+
+  // Go fullscreen + lock to landscape while the presentation is open. Exiting
+  // fullscreen (e.g. Escape, which the browser eats before our keydown handler)
+  // navigates back — preserving the "Escape leaves the presentation" behaviour.
+  useFullscreenLandscape(() => navigate(-1));
 
   const flatSlides = state.segments.flatMap((s) => s.slides);
   const slidesLength = flatSlides.length;


### PR DESCRIPTION
- Enter fullscreen and lock orientation to landscape while presenting, via a reusable `useFullscreenLandscape` hook (new src/hooks folder)
- Treat leaving fullscreen as navigate-back: in fullscreen the browser eats the Escape keydown to exit fullscreen, so listen for `fullscreenchange` and go back on exit — restoring "Escape leaves the presentation"
- Assorted UI/styling tweaks (search input/bar, header, home, root layout)