### PR TITLE
feat(home): full-bleed hero section with responsive layout polish

### DIFF
--- a/frontend/src/components/RecentlyViewed.tsx
+++ b/frontend/src/components/RecentlyViewed.tsx
@@ -68,7 +68,7 @@ export default function RecentlyViewed({ contentIds }: RecentlyViewedProps) {
           </div>
         </div>
       ) : (
-        <div className="pb-4 pt-4 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 max-h-52 lg:max-h-82 overflow-auto">
+        <div className="pb-4 pt-4 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 max-h-52 lg:max-h-120 overflow-auto">
           {items.map((content) => (
             <Link
               key={content.id}

--- a/frontend/src/layouts/RootLayout.tsx
+++ b/frontend/src/layouts/RootLayout.tsx
@@ -5,12 +5,12 @@ import SettingsModal from "@components/modals/SettingsModal";
 
 export default function RootLayout() {
   return (
-    <div className="min-h-screen bg-base-100 flex flex-col w-full" dir="rtl">
+    <div className="min-h-screen bg-base-100 flex flex-col w-full overflow-x-clip" dir="rtl">
       {/* Header */}
       <Header />
 
       {/* Main Content */}
-      <main className="flex-1 w-11/12 lg:w-10/12 mx-auto">
+      <main className="flex-1 w-11/12 md:w-10/12 lg:w-9/12 xl:w-6/12 mx-auto">
         <Outlet />
       </main>
 

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -23,23 +23,24 @@ export default function HomePage() {
   };
 
   return (
-    <div className="flex flex-col items-center min-h-screen py-8">
+    <div className="flex flex-col items-center min-h-screen pb-8">
       <FABCreate />
       <div className="w-full px-4 flex flex-col gap-10">
-        {/* Enhanced Hero Section with Background Image */}
-        <div className="relative rounded-3xl shadow-2xl flex flex-col gap-6 lg:gap-12 p-8 md:p-26 lg:p-32">
+        <div className="relative w-screen mx-[calc(50%-50vw)] flex flex-col gap-6 lg:gap-12 p-8 md:p-26 lg:p-32 items-center">
           {/* Background Image with Overlay */}
-          <div className="absolute inset-0 bg-cover bg-start rounded-box" style={{ backgroundImage: "url('/hero.jpg')" }}></div>
-
+          <div
+            className="absolute inset-0 bg-cover bg-start mask-[linear-gradient(to_top,transparent_0%,black_50%)]"
+            style={{ backgroundImage: "url('/hero.jpg')" }}
+          ></div>
           {/* Gradient Overlay for better text readability */}
-          <div className="absolute inset-0 bg-linear-to-br from-transparent via-base-100/80 to-transparent rounded-box"></div>
+          <div className="absolute inset-0 bg-linear-to-br from-transparent via-base-100/80 to-transparent"></div>
 
           {/* Hero Text */}
           <div className="text-center flex flex-col gap-2 lg:gap-6 fade-in-bottom">
             <h1 className="text-2xl md:text-4xl lg:text-6xl stroke-3 stroke-base-content font-extrabold drop-shadow-2xl text-shadow-lg text-base-content">
               أهلاً بك في هيمنوس
               <sup className="text-2xl align-super">
-                <a href="#footnote-1" className="underline text-blue-800/80 text-[8px]">
+                <a href="#footnote-1" className="underline text-blue-800/80 text-xs">
                   1
                 </a>
               </sup>
@@ -49,7 +50,7 @@ export default function HomePage() {
             </p>
           </div>
           {/* Search Bar */}
-          <div className="fade-in-bottom z-20">
+          <div className="fade-in-bottom z-20 w-full md:w-10/12 lg:w-9/12 xl:w-6/12">
             <SearchBar onSelectResult={handleSelectResult} className="w-full" />
           </div>
         </div>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -73,4 +73,7 @@ export default defineConfig({
   optimizeDeps: {
     exclude: ["@electric-sql/pglite"],
   },
+  server: {
+    host: "0.0.0.0",
+  },
 });


### PR DESCRIPTION
- hero breaks out of the centered <main> via negative margins (mx-[calc(50%-50vw)]) so the background image + gradient span the full viewport width flush under the header; margin-based instead of left+translate because RTL blocks anchor to the right edge, which made the transform variant land off-center
- fade the hero image bottom with a mask gradient and center its content; constrain the search bar width on wider screens
- tighten <main> width per breakpoint (md:10/12, lg:9/12, xl:6/12)
- taller recently-viewed grid on large screens
- vite: serve dev on 0.0.0.0 for testing from mobile devices on the LAN