### PR TITLE
feat(presentation): language filter, Tailwind block styles, and fixes

### DIFF
--- a/frontend/src/components/base/Footer.tsx
+++ b/frontend/src/components/base/Footer.tsx
@@ -9,7 +9,7 @@ export default function Footer() {
           <p className="font-bold font-amiri">"سَبْعَ مَرَّاتٍ فِي النَّهَارِ سَبَّحْتُكَ عَلَى أَحْكَامِ عَدْلِكَ."</p>
           <span className="font-bold font-amiri">(مز ١١٩: ١٦٤)</span>
         </div>
-        <p>Copyright © {new Date().getFullYear()} - All right reserved</p>
+        <p className="opacity-50">Copyright © {new Date().getFullYear()} - All right reserved</p>
       </aside>
       {/* <nav>
         <div className="grid grid-flow-col gap-4">

--- a/frontend/src/components/presentation/BookTocDrawer.tsx
+++ b/frontend/src/components/presentation/BookTocDrawer.tsx
@@ -73,7 +73,7 @@ export default function BookTocDrawer({ book, theme, children }: BookTocDrawerPr
   };
 
   return (
-    <div data-theme={theme} className="drawer drawer-end h-screen w-full">
+    <div data-theme={theme} className="drawer h-screen w-full">
       <input id={BOOK_TOC_DRAWER_ID} type="checkbox" className="drawer-toggle" />
 
       <div className="drawer-content">{children}</div>

--- a/frontend/src/components/presentation/PreviewSlide.tsx
+++ b/frontend/src/components/presentation/PreviewSlide.tsx
@@ -1,5 +1,5 @@
 import type { components } from "@/db/models";
-import { getPreviewBlockStyle } from "./blockTypeStyles";
+import { getPreviewBlockClass } from "./blockTypeStyles";
 import { SlideBlockContent } from "./SlideBlock";
 
 type SlideView = components["schemas"]["SlideView"];
@@ -18,9 +18,8 @@ export default function PreviewSlide({ slide }: { slide: SlideView }) {
                   blockId={block.id}
                   content={block.content}
                   disabled={true}
-                  style={getPreviewBlockStyle(block.metadata)}
                   placeholder="لا يوجد محتوي"
-                  className="cursor-default"
+                  className={`cursor-default ${getPreviewBlockClass(block.metadata)}`}
                 />
               ))}
             </div>

--- a/frontend/src/components/presentation/SlideBlock.tsx
+++ b/frontend/src/components/presentation/SlideBlock.tsx
@@ -1,7 +1,6 @@
-import type { CSSProperties } from "react";
 import { FiPlus } from "react-icons/fi";
 import { BlockType } from "../../db/models";
-import { getFullSlideBlockStyle } from "./blockTypeStyles";
+import { getFullSlideBlockClass } from "./blockTypeStyles";
 import CreateBlockMenu from "./CreateBlockMenu";
 import KebabMenu from "./KebabMenu";
 import { useBlockMenu } from "./useBlockMenu";
@@ -20,7 +19,6 @@ export function SlideBlockContent({
   content,
   disabled,
   onChange,
-  style,
   className = "",
   placeholder,
 }: {
@@ -28,7 +26,6 @@ export function SlideBlockContent({
   content: string;
   disabled: boolean;
   onChange?: (e: ContentEditableEvent) => void;
-  style: CSSProperties;
   className?: string;
   placeholder?: string;
 }) {
@@ -39,8 +36,7 @@ export function SlideBlockContent({
       onChange={onChange ?? (() => {})}
       disabled={disabled}
       data-placeholder={placeholder}
-      className={`w-full text-center resize-none shrink-0 overflow-hidden whitespace-pre-wrap block bg-transparent border-none outline-none text-base-content ${className}`}
-      style={style}
+      className={`w-full resize-none shrink-0 overflow-hidden whitespace-pre-wrap block bg-transparent border-none outline-none text-base-content ${className}`}
     />
   );
 }
@@ -122,8 +118,7 @@ export default function SlideBlock({ block, blockIndex, columnId, totalBlocks }:
           disabled={!state.isEditingMode}
           onChange={handleChange}
           placeholder={state.isEditingMode ? "اكتب..." : "لا يوجد محتوي"}
-          style={getFullSlideBlockStyle(block.metadata, presentationSettings.fontSizeScale)}
-          className={`${presentationSettings.fontFamily} ${state.isEditingMode ? "animate-pulse focus:ring-2 focus:ring-current rounded-lg cursor-text" : "cursor-default"}`}
+          className={`${presentationSettings.fontFamily} ${getFullSlideBlockClass(block.metadata)} ${state.isEditingMode ? "animate-pulse focus:ring-2 focus:ring-current rounded-lg cursor-text" : "cursor-default"}`}
         />
       </div>
       {renderBlockDivider("after")}

--- a/frontend/src/components/presentation/SlideContent.tsx
+++ b/frontend/src/components/presentation/SlideContent.tsx
@@ -1,7 +1,9 @@
+import type { CSSProperties } from "react";
 import { FcAddRow } from "react-icons/fc";
 import SlideRow from "./SlideRow";
 import type { components } from "../../db/models";
 import { usePresentation } from "../../contexts/PresentationContext";
+import useHymnosStore from "../../store";
 
 type SlideView = components["schemas"]["SlideView"];
 
@@ -11,6 +13,7 @@ interface SlideContentProps {
 
 export default function SlideContent({ slide }: SlideContentProps) {
   const { state, dispatch } = usePresentation();
+  const fontSizeScale = useHymnosStore((s) => s.presentationSettings.fontSizeScale);
 
   const renderHorizontalDivider = (row: any, rowIndex: number) => (
     <div key={`row-divider-${row.id}-${rowIndex}`} className="relative w-full h-px divider divider-vertical divider-neutral/50 p-4">
@@ -47,5 +50,12 @@ export default function SlideContent({ slide }: SlideContentProps) {
     rowElements.unshift(renderHorizontalDivider(slide.slide_rows[0], -1));
   }
 
-  return <div className={`w-11/12 h-11/12 p-4 flex flex-col overflow-auto no-scrollbar justify-center-safe`}>{rowElements}</div>;
+  return (
+    <div
+      style={{ "--font-scale": fontSizeScale } as CSSProperties}
+      className={`w-11/12 h-11/12 p-4 flex flex-col overflow-auto no-scrollbar justify-center-safe`}
+    >
+      {rowElements}
+    </div>
+  );
 }

--- a/frontend/src/components/presentation/SlideRow.tsx
+++ b/frontend/src/components/presentation/SlideRow.tsx
@@ -4,6 +4,7 @@ import { useRowMenu } from "./useRowMenu";
 import SlideColumn from "./SlideColumn";
 import type { components } from "../../db/models";
 import { usePresentation } from "../../contexts/PresentationContext";
+import useHymnosStore from "../../store";
 
 type SlideRowView = components["schemas"]["SlideRowView"];
 
@@ -14,6 +15,13 @@ interface SlideRowProps {
 
 export default function SlideRow({ rowData, isOnlyRow }: SlideRowProps) {
   const { state, dispatch } = usePresentation();
+  const hiddenLanguages = useHymnosStore((s) => s.presentationSettings.hiddenLanguages);
+
+  // Hide columns whose language is toggled off (view mode only). Never blank a
+  // row: if every column would be hidden, fall back to showing them all.
+  const hidden = state.isEditingMode ? [] : hiddenLanguages ?? [];
+  const filtered = hidden.length ? rowData.slide_columns.filter((c) => !hidden.includes(c.language.id)) : rowData.slide_columns;
+  const slideColumns = filtered.length ? filtered : rowData.slide_columns;
 
   // Row KebabMenu items
   const rowMenuItems = useRowMenu({
@@ -40,8 +48,8 @@ export default function SlideRow({ rowData, isOnlyRow }: SlideRowProps) {
   );
 
   // Generate column elements with dividers using flatMap
-  const isOnlyColumn = rowData.slide_columns.length <= 1;
-  const columnsWithDividers = rowData.slide_columns.flatMap((column, index, array) => {
+  const isOnlyColumn = slideColumns.length <= 1;
+  const columnsWithDividers = slideColumns.flatMap((column, index, array) => {
     const elements = [<SlideColumn key={column.id} columnData={column} rowId={rowData.id} isOnlyColumn={isOnlyColumn} />];
 
     // Add divider after (except for last item in non-edit mode)

--- a/frontend/src/components/presentation/Toolbar.tsx
+++ b/frontend/src/components/presentation/Toolbar.tsx
@@ -1,9 +1,12 @@
 import { FiInfo, FiShare2, FiEdit, FiTrash2, FiX, FiCheck, FiPlus, FiSettings, FiList, FiImage } from "react-icons/fi";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { usePresentation } from "../../contexts/PresentationContext";
 import { BACKGROUND_MODAL_ID } from "./BackgroundModal";
 import { useAutoHide } from "@hooks/useAutoHide";
 import useHymnosStore from "../../store";
+import type { components } from "../../db/models";
+
+type Language = components["schemas"]["Language"];
 
 const THEMES = ["light", "synthwave", "retro", "cyberpunk", "valentine", "halloween", "black", "luxury", "lemonade", "night", "coffee"];
 const FONT_FAMILIES = ["font-rubik", "font-amiri", "font-cairo", "font-lalezar", "font-lateef", "font-rakkas"];
@@ -23,7 +26,27 @@ export function Toolbar({ isBibleChapter, onInfo, onShare, tocDrawerId }: Toolba
   const [isHoveringToolbar, setIsHoveringToolbar] = useState(false);
   const isVisible = useAutoHide(3000, isHoveringToolbar);
 
+  // Unique languages present across all slide columns (for the language filter).
+  const availableLanguages = useMemo(() => {
+    const byId = new Map<string, Language>();
+    for (const seg of state.segments)
+      for (const slide of seg.slides)
+        for (const row of slide.slide_rows ?? [])
+          for (const col of row.slide_columns ?? []) if (col.language) byId.set(col.language.id, col.language);
+    return [...byId.values()];
+  }, [state.segments]);
+
   if (!isVisible) return null;
+
+  const hiddenLanguages = presentationSettings.hiddenLanguages ?? [];
+  const shownCount = availableLanguages.filter((l) => !hiddenLanguages.includes(l.id)).length;
+  const toggleLanguage = (id: string) => {
+    const isHidden = hiddenLanguages.includes(id);
+    // Keep at least one language selected: don't allow hiding the last visible one.
+    if (!isHidden && shownCount <= 1) return;
+    const next = isHidden ? hiddenLanguages.filter((x) => x !== id) : [...hiddenLanguages, id];
+    setPresentationSettings({ hiddenLanguages: next });
+  };
 
   const increaseFontSize = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -155,6 +178,31 @@ export function Toolbar({ isBibleChapter, onInfo, onShare, tocDrawerId }: Toolba
                 </div>
               </div>
             </li>
+
+            {/* Language filter — hide columns of unneeded languages (shown when 2+ languages) */}
+            {availableLanguages.length > 1 && (
+              <li>
+                <details>
+                  <summary>اللغات</summary>
+                  <ul className="flex flex-col gap-1 p-2">
+                    {availableLanguages.map((lang) => (
+                      <li key={lang.id}>
+                        <label className="flex items-center gap-2 cursor-pointer" onClick={(e) => e.stopPropagation()}>
+                          <input
+                            type="checkbox"
+                            className="checkbox checkbox-sm"
+                            checked={!hiddenLanguages.includes(lang.id)}
+                            disabled={shownCount <= 1 && !hiddenLanguages.includes(lang.id)}
+                            onChange={() => toggleLanguage(lang.id)}
+                          />
+                          <span>{lang.name}</span>
+                        </label>
+                      </li>
+                    ))}
+                  </ul>
+                </details>
+              </li>
+            )}
 
             {/* Background Image */}
             <li>

--- a/frontend/src/components/presentation/blockTypeStyles.ts
+++ b/frontend/src/components/presentation/blockTypeStyles.ts
@@ -1,68 +1,45 @@
-import type { CSSProperties } from "react";
 import { BlockType } from "@/db/models";
-
-interface BlockConfig {
-  /** vh multiplier used in the full-screen clamp() calculation */
-  vhScale: number;
-  clampMinRem: number;
-  clampMaxRem: number;
-  /** Fixed font size used in the compact preview carousel */
-  previewFontSize: string;
-  opacity: number;
-  fontWeight: number;
-  lineHeight: number;
-}
-
-const BLOCK_CONFIG: Record<string, BlockConfig> = {
-  [BlockType.h1]: {
-    vhScale: 8,  clampMinRem: 1.5,  clampMaxRem: 16,
-    previewFontSize: "1.5rem",  opacity: 0.7, fontWeight: 700, lineHeight: 1.5,
-  },
-  [BlockType.h2]: {
-    vhScale: 6,  clampMinRem: 1.25, clampMaxRem: 14,
-    previewFontSize: "1.25rem", opacity: 0.7, fontWeight: 600, lineHeight: 1.5,
-  },
-  [BlockType.h3]: {
-    vhScale: 4,  clampMinRem: 1,    clampMaxRem: 12,
-    previewFontSize: "1.1rem",  opacity: 0.7, fontWeight: 500, lineHeight: 1.5,
-  },
-  [BlockType.paragraph]: {
-    vhScale: 8,  clampMinRem: 1,    clampMaxRem: 24,
-    previewFontSize: "1rem",    opacity: 1.0, fontWeight: 400, lineHeight: 2.0,
-  },
-};
 
 /** Block styling stored in slide_block.metadata, e.g. { type: "h1", align: "center" }. */
 type BlockStyle = { type?: string; align?: string } | null | undefined;
 
-function cfg(style: BlockStyle): BlockConfig {
-  return BLOCK_CONFIG[style?.type ?? ""] ?? BLOCK_CONFIG[BlockType.paragraph];
+// Full-screen presentation classes. The font size scales with the `--font-scale`
+// CSS variable (set on the slide container from the user's font-size setting) via
+// a clamp(), so it stays a static, JIT-discoverable arbitrary value while still
+// responding to the setting at runtime.
+const FULL_CLASSES: Record<string, string> = {
+  [BlockType.h1]: "text-[clamp(1.5rem,calc(var(--font-scale,1)*8vh),16rem)] font-bold leading-normal text-primary",
+  [BlockType.h2]: "text-[clamp(1.25rem,calc(var(--font-scale,1)*6vh),14rem)] font-semibold leading-normal text-primary",
+  [BlockType.h3]: "text-[clamp(1rem,calc(var(--font-scale,1)*4vh),12rem)] font-medium leading-normal text-primary",
+  [BlockType.paragraph]: "text-[clamp(1rem,calc(var(--font-scale,1)*8vh),24rem)] font-normal leading-loose",
+};
+
+// Compact preview-carousel classes (fixed sizes, no scaling).
+const PREVIEW_CLASSES: Record<string, string> = {
+  [BlockType.h1]: "text-[1.5rem] font-bold leading-normal text-primary",
+  [BlockType.h2]: "text-[1.25rem] font-semibold leading-normal text-primary",
+  [BlockType.h3]: "text-[1.1rem] font-medium leading-normal text-primary",
+  [BlockType.paragraph]: "text-[1rem] font-normal leading-loose",
+};
+
+const ALIGN_CLASSES: Record<string, string> = {
+  center: "text-center",
+  left: "text-left",
+  right: "text-right",
+};
+
+function blockClasses(map: Record<string, string>, style: BlockStyle): string {
+  const base = map[style?.type ?? ""] ?? map[BlockType.paragraph];
+  const align = ALIGN_CLASSES[style?.align ?? "center"] ?? ALIGN_CLASSES.center;
+  return `${base} ${align}`;
 }
 
-function alignStyle(style: BlockStyle): CSSProperties {
-  return style?.align ? { textAlign: style.align as CSSProperties["textAlign"] } : {};
+/** Tailwind classes for a block in the full-screen presentation. */
+export function getFullSlideBlockClass(style: BlockStyle): string {
+  return blockClasses(FULL_CLASSES, style);
 }
 
-/** Inline styles for a block rendered in the full-screen presentation. */
-export function getFullSlideBlockStyle(style: BlockStyle, scale: number): CSSProperties {
-  const c = cfg(style);
-  return {
-    fontSize: `clamp(${c.clampMinRem}rem, ${scale * c.vhScale}vh, ${c.clampMaxRem}rem)`,
-    fontWeight: c.fontWeight,
-    lineHeight: c.lineHeight,
-    opacity: c.opacity,
-    ...alignStyle(style),
-  };
-}
-
-/** Inline styles for a block rendered in the compact slide preview carousel. */
-export function getPreviewBlockStyle(style: BlockStyle): CSSProperties {
-  const c = cfg(style);
-  return {
-    fontSize: c.previewFontSize,
-    fontWeight: c.fontWeight,
-    lineHeight: c.lineHeight,
-    opacity: c.opacity,
-    ...alignStyle(style),
-  };
+/** Tailwind classes for a block in the compact slide preview carousel. */
+export function getPreviewBlockClass(style: BlockStyle): string {
+  return blockClasses(PREVIEW_CLASSES, style);
 }

--- a/frontend/src/contexts/PresentationContext.reducer.ts
+++ b/frontend/src/contexts/PresentationContext.reducer.ts
@@ -126,7 +126,10 @@ export const presentationReducer = produce((draft: PresentationState, action: Pr
     // === EDIT MODE ===
     case "ENTER_EDIT_MODE":
       draft.isEditingMode = true;
-      draft.segmentsBackup = JSON.parse(JSON.stringify(draft.segments));
+      // Snapshot by reference, not a deep clone: Immer's structural sharing keeps
+      // this cheap, and untouched segments keep the same reference after edits — so
+      // submitEdit can detect changes with an O(1) reference check.
+      draft.segmentsBackup = draft.segments;
       break;
 
     case "CANCEL_EDIT":

--- a/frontend/src/contexts/PresentationContext.tsx
+++ b/frontend/src/contexts/PresentationContext.tsx
@@ -26,7 +26,10 @@ interface PresentationProviderProps {
   startSlide?: string;
 }
 
-async function loadPresentation(db: PGliteWithLive, uuid: string): Promise<{ contentId: string; contentType: string; segments: PresentationSegment[] }> {
+async function loadPresentation(
+  db: PGliteWithLive,
+  uuid: string,
+): Promise<{ contentId: string; contentType: string; segments: PresentationSegment[] }> {
   const res = await db.query(`SELECT get_content_slides($1)::json as r`, [uuid]);
   if (res.rows.length === 0) throw new Error("not found");
   const raw = (res.rows[0] as { r: ContentSlidesView }).r;
@@ -138,10 +141,15 @@ export function PresentationProvider({ children, uuid, startSlide }: Presentatio
     }
 
     try {
-      for (const seg of state.segments) {
-        if (seg.content_type !== "bible_chapter") {
-          await upsertSlides(db, seg.content_id, seg.content_type as any, seg.slides);
-        }
+      const backup = state.segmentsBackup;
+      for (let i = 0; i < state.segments.length; i++) {
+        const seg = state.segments[i];
+        if (seg.content_type === "bible_chapter") continue;
+
+        // Avoid upserting slides that didn't change.
+        if (backup?.[i]?.slides === seg.slides) continue;
+
+        await upsertSlides(db, seg.content_id, seg.content_type as any, seg.slides);
       }
 
       // Force flush to IndexedDB (needed because relaxedDurability is enabled)
@@ -154,7 +162,7 @@ export function PresentationProvider({ children, uuid, startSlide }: Presentatio
       toast.error("تعذّر حفظ الشرائح");
       throw error;
     }
-  }, [state.segments, db]);
+  }, [state.segments, state.segmentsBackup, db]);
 
   // Memoized so consumers don't re-render when the provider re-renders for
   // reasons other than a state change (dispatch is stable across renders).

--- a/frontend/src/db/crud/read/localstorage.ts
+++ b/frontend/src/db/crud/read/localstorage.ts
@@ -1,7 +1,7 @@
 import { getBibleChapter } from "@/db/crud/read/bible";
 import { getContentById } from "@/db/crud/read/content";
 import { getHymnById } from "@/db/crud/read/hymn";
-import { getBookSection } from "@/db/crud/read/liturgy";
+import { getBook, getBookSection } from "@/db/crud/read/liturgy";
 import { ContentType } from "@/db/models";
 import type { PGliteWithLive } from "@electric-sql/pglite/live";
 
@@ -44,6 +44,16 @@ export async function getLastViewedContentDetails(db: PGliteWithLive, id: string
         `${hymnDetails.author ? `المؤلف: ${hymnDetails.author}` : ""}${hymnDetails.composer ? ` • الملحن: ${hymnDetails.composer}` : ""}`.trim() ||
         "غير محدد",
       contentType: ContentType.hymn,
+    };
+  } else if (content.type === ContentType.book) {
+    const bookDetails = await getBook(db, id);
+    if (!bookDetails) return null;
+
+    return {
+      id: id,
+      name: bookDetails.name || "كتاب",
+      description: bookDetails.description || (bookDetails.author ? `المؤلف: ${bookDetails.author}` : "") || "كتاب",
+      contentType: ContentType.book,
     };
   } else if (content.type === ContentType.book_section) {
     const sectionDetails = await getBookSection(db, id);

--- a/frontend/src/db/utils/import.ts
+++ b/frontend/src/db/utils/import.ts
@@ -18,7 +18,10 @@ export async function import_tables_from_zip(db: PGliteWithLive, file: File | Bl
     // Import each CSV file from the zip
     for (const fileName of Object.keys(zipContent.files)) {
       const blob = await zipContent.files[fileName].async("blob");
-      const tableName = fileName.split(".")[0];
+      const split = fileName.split(".");
+      const tableName = split[0];
+      const ext = split[1];
+      if (ext != "csv") continue;
 
       if (should_direct_copy) {
         // Copy directly to table from CSV file

--- a/frontend/src/routes/presentation/[uuid].tsx
+++ b/frontend/src/routes/presentation/[uuid].tsx
@@ -63,7 +63,7 @@ function PresentationContent() {
         dispatch({ type: "NEXT_SLIDE" });
       }
     },
-    [state.isEditingMode, dispatch]
+    [state.isEditingMode, dispatch],
   );
 
   // Share handler
@@ -117,7 +117,7 @@ function PresentationContent() {
       >
         <div className="flex flex-col gap-4 text-center">
           <Logo />
-          <p>Copyright © {new Date().getFullYear()} - All right reserved</p>
+          <p className="opacity-50">Copyright © {new Date().getFullYear()} - All right reserved</p>
         </div>
       </div>
     );

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -10,6 +10,7 @@ export interface PresentationSettings {
   backgroundImage?: string; // base64 data URL, persisted to localStorage; undefined = no background
   backgroundBlur?: number; // CSS blur radius in px applied to the background image (default 0)
   backgroundOpacity?: number; // opacity of the background image layer, 0..1 (default 1)
+  hiddenLanguages?: string[]; // language ids whose slide columns are hidden in view mode
 }
 
 export interface HymnosState {


### PR DESCRIPTION
- blockTypeStyles: return Tailwind classes instead of inline CSSProperties; full-screen sizes scale at runtime via a --font-scale CSS variable
- presentation: add per-language column filter toggled from settings menu, guarding against hiding all languages
- perf: skip upsertSlides for unchanged segments using Immer reference equality on the edit backup (avoids rewriting every section on save)
- fix(recently-viewed): resolve book content so presented books appear in the recently-viewed list
- import: skip non-csv entries when importing tables from a zip
- misc: drawer direction, footer styling tweaks